### PR TITLE
WIP: Add the ability to open wikis in the browser

### DIFF
--- a/include/store/store.hpp
+++ b/include/store/store.hpp
@@ -53,6 +53,7 @@ public:
 	std::vector<std::string> GetConsoleEntry(int index) const;
 	std::string GetLastUpdatedEntry(int index) const;
 	std::string GetLicenseEntry(int index) const;
+	std::string GetWikiEntry(int index) const;
 	C2D_Image GetIconEntry(int index) const;
 	std::string GetFileSizes(int index, const std::string &entry) const;
 	std::vector<std::string> GetScreenshotList(int index) const;

--- a/include/store/storeEntry.hpp
+++ b/include/store/storeEntry.hpp
@@ -43,6 +43,7 @@ public:
 	std::string GetConsole() const { return this->Console; };
 	std::string GetLastUpdated() const { return this->LastUpdated; };
 	std::string GetLicense() const { return this->License; };
+	std::string GetWiki() const { return this->Wiki; };
 	int GetMarks() const { return this->Marks; };
 
 	C2D_Image GetIcon() const { return this->Icon; };
@@ -66,7 +67,7 @@ public:
 	};
 
 private:
-	std::string Title, Author, Description, Category, Version, Console, LastUpdated, License, MarkString, ReleaseNotes;
+	std::string Title, Author, Description, Category, Version, Console, LastUpdated, License, MarkString, ReleaseNotes, Wiki;
 	C2D_Image Icon;
 	int SheetIndex, EntryIndex, Marks;
 	std::vector<std::string> FullCategory, FullConsole, Sizes, Screenshots, ScreenshotNames;

--- a/source/menu/entryInfo.cpp
+++ b/source/menu/entryInfo.cpp
@@ -33,7 +33,7 @@ static const Structs::ButtonPos btn = { 45, 215, 24, 24 };
 static const Structs::ButtonPos sshot = { 75, 215, 24, 24 };
 static const Structs::ButtonPos notes = { 105, 215, 24, 24 };
 extern bool checkWifiStatus();
-extern bool QueueRuns;
+extern bool exiting, QueueRuns;
 
 /*
 	Draw the Entry Info part.
@@ -97,6 +97,13 @@ void StoreUtils::EntryHandle(bool &showMark, bool &fetch, bool &sFetch, int &mod
 
 		if ((hDown & KEY_X) || (hDown & KEY_TOUCH && touching(touch, notes))) {
 			if (entry->GetReleaseNotes() != "") mode = 7;
+		}
+
+		if (hDown & KEY_SELECT && entry->GetWiki() != "") {
+			APT_PrepareToStartSystemApplet(APPID_WEB);
+			APT_StartSystemApplet(APPID_WEB, entry->GetWiki().c_str(), entry->GetWiki().size(), 0);
+			aptClearChainloader();
+			exiting = true;
 		}
 	}
 }

--- a/source/store/store.cpp
+++ b/source/store/store.cpp
@@ -403,6 +403,22 @@ std::string Store::GetLicenseEntry(int index) const {
 }
 
 /*
+	Return the Wiki of an index.
+
+	int index: The index.
+*/
+std::string Store::GetWikiEntry(int index) const {
+	if (!this->valid) return "";
+	if (index > (int)this->storeJson["storeContent"].size() - 1) return ""; // Empty.
+
+	if (this->storeJson["storeContent"][index]["info"].contains("wiki") && this->storeJson["storeContent"][index]["info"]["wiki"].is_string()) {
+		return this->storeJson["storeContent"][index]["info"]["wiki"];
+	}
+
+	return "";
+}
+
+/*
 	Return a C2D_Image of an index.
 
 	int index: The index.

--- a/source/store/storeEntry.cpp
+++ b/source/store/storeEntry.cpp
@@ -44,6 +44,7 @@ StoreEntry::StoreEntry(const std::unique_ptr<Store> &store, const std::unique_pt
 	this->Console = StringUtils::FetchStringsFromVector(store->GetConsoleEntry(index));
 	this->LastUpdated = store->GetLastUpdatedEntry(index);
 	this->License = store->GetLicenseEntry(index);
+	this->Wiki = store->GetWikiEntry(index);
 	this->MarkString = StringUtils::GetMarkString(meta->GetMarks(store->GetUniStoreTitle(), this->Title));
 
 	this->Icon = store->GetIconEntry(index);


### PR DESCRIPTION
Currently press SELECT and if the app has one it'll *quit UU* and open the browser
I feel like it should be possible to launch the browser without quitting UU as you can launch it from the home menu while the app is running, but that wasn't working.

- [ ] Add an icon you can touch, probably by release notes is my first though, I'll try find a good one in the morning
- [ ] Maybe make SELECT not open it? I just did that for testing but it might be an alright key for it I guess
- [ ] Add a warning that this will quit UU unless we can figure out how to not quit UU
- [ ] Try fix it quitting UU
- [ ] Anything else?