### PR TITLE
Add safety checks for low SD card space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,6 @@ jobs:
           mkdir -p ~/artifacts
           cp Universal-Updater.3dsx ~/artifacts
           cp Universal-Updater.cia ~/artifacts
-          cp Universal-Updater.elf ~/artifacts
           echo ::set-output name=commit_tag::$(git describe --abbrev=0 --tags)
           echo ::set-output name=commit_hash::$(git log --format=%h -1)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Universal-Updater
 
 on:
   push:
-    branches-ignore: [translation, some-safety-freespace-work]
+    branches-ignore: [translation]
     paths-ignore:
       - 'README.md'
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
           mkdir -p ~/artifacts
           cp Universal-Updater.3dsx ~/artifacts
           cp Universal-Updater.cia ~/artifacts
+          cp Universal-Updater.elf ~/artifacts
           echo ::set-output name=commit_tag::$(git describe --abbrev=0 --tags)
           echo ::set-output name=commit_hash::$(git log --format=%h -1)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Universal-Updater
 
 on:
   push:
-    branches-ignore: [translation]
+    branches-ignore: [translation, some-safety-freespace-work]
     paths-ignore:
       - 'README.md'
   pull_request:

--- a/include/utils/files.hpp
+++ b/include/utils/files.hpp
@@ -34,5 +34,6 @@ Result openFile(Handle *fileHandle, const char *path, bool write);
 Result deleteFile(const char *path);
 Result removeDir(const char *path);
 Result removeDirRecursive(const char *path);
+u64 getAvailableSpace();
 
 #endif

--- a/include/utils/stringutils.hpp
+++ b/include/utils/stringutils.hpp
@@ -34,7 +34,7 @@
 namespace StringUtils {
 	std::string lower_case(const std::string &str);
 	std::string FetchStringsFromVector(const std::vector<std::string> &fetch);
-	std::string formatBytes(int bytes);
+	std::string formatBytes(u64 bytes);
 	std::string GetMarkString(int marks);
 	std::vector<std::string> GetMarks(int marks);
 	std::string format(const char *fmt_str, ...);

--- a/source/init.cpp
+++ b/source/init.cpp
@@ -196,10 +196,6 @@ Result Init::MainLoop() {
 
 		if (!exiting) Gui::ScreenLogic(hDown, hHeld, touch, true, false);
 
-		if (aptCheckHomePressRejected()) {
-			if (Msg::promptMsg(Lang::get("FEATURE_SIDE_EFFECTS"))) aptSetHomeAllowed(true);
-		};
-
 		if (exiting) {
 			if (hDown & KEY_START) fullExit = true; // Make it optionally faster.
 

--- a/source/menu/entryInfo.cpp
+++ b/source/menu/entryInfo.cpp
@@ -50,11 +50,8 @@ void StoreUtils::DrawEntryInfo(const std::unique_ptr<StoreEntry> &entry) {
 		Gui::DrawStringCentered(17, 20, 0.4, UIThemes->TextColor(), entry->GetAuthor(), 273, 0, font);
 		Gui::DrawStringCentered(17, 50, 0.4, UIThemes->TextColor(), entry->GetDescription(), 248, 0, font, C2D_WordWrap);
 
-		Gui::DrawStringCentered(53, 130, 0.4, UIThemes->TextColor(), "Free space: " + std::to_string(getAvailableSpace()), 273, 0, font);
-		Gui::DrawStringCentered(53, 145, 0.4, UIThemes->TextColor(), "Free space: " + StringUtils::formatBytes(getAvailableSpace()), 273, 0, font);
-
-		//Gui::DrawString(53, 130, 0.45, UIThemes->TextColor(), Lang::get("VERSION") + ": " + entry->GetVersion(), 248, 0, font);
-		//Gui::DrawString(53, 145, 0.45, UIThemes->TextColor(), Lang::get("CATEGORY") + ": " + entry->GetCategory(), 248, 0, font);
+		Gui::DrawString(53, 130, 0.45, UIThemes->TextColor(), Lang::get("VERSION") + ": " + entry->GetVersion(), 248, 0, font);
+		Gui::DrawString(53, 145, 0.45, UIThemes->TextColor(), Lang::get("CATEGORY") + ": " + entry->GetCategory(), 248, 0, font);
 		Gui::DrawString(53, 160, 0.45, UIThemes->TextColor(), Lang::get("CONSOLE") + ": " + entry->GetConsole(), 248, 0, font);
 		Gui::DrawString(53, 175, 0.45, UIThemes->TextColor(), Lang::get("LAST_UPDATED") + ": " + entry->GetLastUpdated(), 248, 0, font);
 		Gui::DrawString(53, 190, 0.45, UIThemes->TextColor(), Lang::get("LICENSE") + ": " + entry->GetLicense(), 248, 0, font);

--- a/source/menu/entryInfo.cpp
+++ b/source/menu/entryInfo.cpp
@@ -25,6 +25,7 @@
 */
 
 #include "common.hpp"
+#include "files.hpp"
 #include "storeUtils.hpp"
 #include "structs.hpp"
 
@@ -49,8 +50,11 @@ void StoreUtils::DrawEntryInfo(const std::unique_ptr<StoreEntry> &entry) {
 		Gui::DrawStringCentered(17, 20, 0.4, UIThemes->TextColor(), entry->GetAuthor(), 273, 0, font);
 		Gui::DrawStringCentered(17, 50, 0.4, UIThemes->TextColor(), entry->GetDescription(), 248, 0, font, C2D_WordWrap);
 
-		Gui::DrawString(53, 130, 0.45, UIThemes->TextColor(), Lang::get("VERSION") + ": " + entry->GetVersion(), 248, 0, font);
-		Gui::DrawString(53, 145, 0.45, UIThemes->TextColor(), Lang::get("CATEGORY") + ": " + entry->GetCategory(), 248, 0, font);
+		Gui::DrawStringCentered(53, 130, 0.4, UIThemes->TextColor(), "Free space: " + std::to_string(getAvailableSpace()), 273, 0, font);
+		Gui::DrawStringCentered(53, 145, 0.4, UIThemes->TextColor(), "Free space: " + StringUtils::formatBytes(getAvailableSpace()), 273, 0, font);
+
+		//Gui::DrawString(53, 130, 0.45, UIThemes->TextColor(), Lang::get("VERSION") + ": " + entry->GetVersion(), 248, 0, font);
+		//Gui::DrawString(53, 145, 0.45, UIThemes->TextColor(), Lang::get("CATEGORY") + ": " + entry->GetCategory(), 248, 0, font);
 		Gui::DrawString(53, 160, 0.45, UIThemes->TextColor(), Lang::get("CONSOLE") + ": " + entry->GetConsole(), 248, 0, font);
 		Gui::DrawString(53, 175, 0.45, UIThemes->TextColor(), Lang::get("LAST_UPDATED") + ": " + entry->GetLastUpdated(), 248, 0, font);
 		Gui::DrawString(53, 190, 0.45, UIThemes->TextColor(), Lang::get("LICENSE") + ": " + entry->GetLicense(), 248, 0, font);

--- a/source/menu/settings.cpp
+++ b/source/menu/settings.cpp
@@ -272,8 +272,7 @@ static void SettingsHandleMain(int &page, bool &dspSettings, int &storeMode, int
 			Overlays::ShowCredits();
 
 		} else if (touching(touch, mainButtons[6])) {
-			if (QueueRuns) exiting = Msg::promptMsg(Lang::get("FEATURE_SIDE_EFFECTS"));
-			else exiting = true;
+			if (!QueueRuns) exiting = true;
 		}
 	}
 
@@ -313,8 +312,7 @@ static void SettingsHandleMain(int &page, bool &dspSettings, int &storeMode, int
 				break;
 
 			case 6:
-				if (QueueRuns) exiting = Msg::promptMsg(Lang::get("FEATURE_SIDE_EFFECTS"));
-				else exiting = true;
+				if (!QueueRuns) exiting = true;
 				break;
 		}
 	}

--- a/source/utils/cia.cpp
+++ b/source/utils/cia.cpp
@@ -126,6 +126,8 @@ Result Title::Install(const char *ciaPath, bool updatingSelf) {
 		return ret;
 	}
 
+	if (getAvailableSpace() < size) return -1; // Out of space.
+
 	ret = AM_StartCiaInstall(media, &ciaHandle);
 	if (R_FAILED(ret)) {
 		printf("Error in:\nAM_StartCiaInstall\n");

--- a/source/utils/extract.cpp
+++ b/source/utils/extract.cpp
@@ -25,6 +25,7 @@
 */
 
 #include "extract.hpp"
+#include "files.hpp"
 #include "queueSystem.hpp"
 #include "scriptUtils.hpp"
 #include <archive.hpp>
@@ -65,6 +66,8 @@ Result getExtractedSize(const std::string &archivePath, const std::string &wante
 }
 
 Result extractArchive(const std::string &archivePath, const std::string &wantedFile, const std::string &outputPath) {
+	if (getAvailableSpace() < extractSize) return -1; // Out of space.
+
 	archive *a = archive_read_new();
 	archive_entry *entry;
 

--- a/source/utils/files.cpp
+++ b/source/utils/files.cpp
@@ -25,6 +25,8 @@
 */
 
 #include "files.hpp"
+#include <sys/stat.h>
+#include <sys/statvfs.h>
 
 FS_Path getPathInfo(const char *path, FS_ArchiveID *archive) {
 	*archive = ARCHIVE_SDMC;
@@ -127,4 +129,13 @@ Result removeDirRecursive(const char *path) {
 	FSUSER_CloseArchive(archive);
 
 	return ret;
+}
+
+/* Code borrowed from GodMode9i:
+	https://github.com/DS-Homebrew/GodMode9i/blob/d68ac105e68b4a1fc2c706a08c7a394255c325c2/arm9/source/driveOperations.cpp#L166-L170
+*/
+u64 getAvailableSpace() {
+	struct statvfs st;
+	statvfs("sdmc:/", &st);
+	return (u64)st.f_bsize * (u64)st.f_bavail;
 }

--- a/source/utils/stringutils.cpp
+++ b/source/utils/stringutils.cpp
@@ -65,14 +65,15 @@ std::string StringUtils::FetchStringsFromVector(const std::vector<std::string> &
 /*
 	adapted from GM9i's byte parsing.
 */
-std::string StringUtils::formatBytes(int bytes) {
+std::string StringUtils::formatBytes(u64 bytes) {
 	char out[32];
 
-	if (bytes == 1)							snprintf(out, sizeof(out), "%d Byte", bytes);
-	else if (bytes < 1024)					snprintf(out, sizeof(out), "%d Bytes", bytes);
-	else if (bytes < 1024 * 1024)			snprintf(out, sizeof(out), "%.1f KiB", (float)bytes / 1024);
-	else if (bytes < 1024 * 1024 * 1024)	snprintf(out, sizeof(out), "%.1f MiB", (float)bytes / 1024 / 1024);
-	else									snprintf(out, sizeof(out), "%.1f GiB", (float)bytes / 1024 / 1024 / 1024);
+	if (bytes == 1)					snprintf(out, sizeof(out), "%lld Byte", bytes);
+	else if (bytes < 1ull << 10)	snprintf(out, sizeof(out), "%lld Bytes", bytes);
+	else if (bytes < 1ull << 20)	snprintf(out, sizeof(out), "%.1f KiB", (float)bytes / 1024);
+	else if (bytes < 1ull << 30)	snprintf(out, sizeof(out), "%.1f MiB", (float)bytes / 1024 / 1024);
+	else if (bytes < 1ull << 40)	snprintf(out, sizeof(out), "%.1f GiB", (float)bytes / 1024 / 1024 / 1024);
+	else							snprintf(out, sizeof(out), "%.1f TiB", (float)bytes / 1024 / 1024 / 1024 / 1024);
 
 	return out;
 }


### PR DESCRIPTION
- Adds safety checks before downloading, extracting, or installing cias for low SD card space
  - [x] Might be good to add to copying files too
- Also disables the <kbd>HOME</kbd> button and exit option in settings when the queue is running
- Fixes #89