### PR TITLE
Check for download cancellation more frequently

### DIFF
--- a/source/utils/download.cpp
+++ b/source/utils/download.cpp
@@ -79,6 +79,9 @@ static int curlProgress(CURL *hnd,
 	downloadTotal = dltotal;
 	downloadNow = dlnow;
 
+	if (writeError) return 1;
+	if (QueueSystem::CancelCallback) return 1;
+
 	return 0;
 }
 


### PR DESCRIPTION
The progress callback (`CURLOPT_XFERINFOFUNCTION`) is called at least once per second, so it can also be used to cancel downloads.

Fixes #96