### PR TITLE
workflow: Allow only one publish/upload action at the same time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ startsWith(github.ref, 'refs/pull') && github.ref || 'publish' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -7,6 +7,9 @@ on:
       - 'romfs/lang/en/**'
   workflow_dispatch:
 
+concurrency:
+  group: crowdin-upload
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This prevents race condition if a later publish/upload job runs/finished earlier than an older one. Applies to non-PR build and Crowdin upload.