### PR TITLE
Use entry's accent color for release notes title bar

### DIFF
--- a/include/store/storeUtils.hpp
+++ b/include/store/storeUtils.hpp
@@ -95,7 +95,7 @@ namespace StoreUtils {
 	size_t FindSplitPoint(const std::string &str, const std::vector<std::string> splitters);
 	void ProcessReleaseNotes(std::string ReleaseNotes);
 
-	void DrawReleaseNotes(const int &scrollOffset, const std::string &title);
+	void DrawReleaseNotes(const int &scrollOffset, const std::unique_ptr<StoreEntry> &entry);
 	void ReleaseNotesLogic(int &scrollOffset, int &scrollDelta, int &storeMode);
 
 	bool compareTitleDescending(const std::unique_ptr<StoreEntry> &a, const std::unique_ptr<StoreEntry> &b);

--- a/source/menu/releaseNotes.cpp
+++ b/source/menu/releaseNotes.cpp
@@ -78,8 +78,8 @@ void StoreUtils::ProcessReleaseNotes(std::string releaseNotes) {
 	} while (splitPos != std::string::npos);
 }
 
-void StoreUtils::DrawReleaseNotes(const int &scrollOffset, const std::string &title) {
-	if (title != "" && StoreUtils::store) {
+void StoreUtils::DrawReleaseNotes(const int &scrollOffset, const std::unique_ptr<StoreEntry> &entry) {
+	if (entry && StoreUtils::store) {
 		Gui::ScreenDraw(Bottom);
 		Gui::Draw_Rect(0, 26, 320, 214, UIThemes->BGColor());
 		
@@ -88,10 +88,11 @@ void StoreUtils::DrawReleaseNotes(const int &scrollOffset, const std::string &ti
 			if (25 + i * fontHeight > scrollOffset && 25 + i * fontHeight < scrollOffset + 240.0f) 
 			Gui::DrawString(5, 25 + i * fontHeight - scrollOffset, 0.5f, UIThemes->TextColor(), wrappedNotes[i], 310, 0, font);
 		}
+		uint32_t accentColor = config->useAccentColor() && !config->changelog() ? entry->GetAccentColor() : 0;
 
-		Gui::Draw_Rect(0, 0, 320, 25, UIThemes->BarColor());
+		Gui::Draw_Rect(0, 0, 320, 25, accentColor ? accentColor : UIThemes->EntryBar());
 		Gui::Draw_Rect(0, 25, 320, 1, UIThemes->BarOutline());
-		Gui::DrawStringCentered(0, 1, 0.7f, UIThemes->TextColor(), title, 310, 0, font);
+		Gui::DrawStringCentered(0, 1, 0.7f, accentColor ? WHITE : UIThemes->TextColor(), config->changelog() ? std::string("Universal-Updater ") + C_V : entry->GetTitle(), 310, 0, font);
 		
 		GFX::DrawIcon(sprites_arrow_idx, back.x, back.y, UIThemes->TextColor());
 

--- a/source/screens/mainScreen.cpp
+++ b/source/screens/mainScreen.cpp
@@ -170,8 +170,7 @@ void MainScreen::Draw(void) const {
 	StoreUtils::DrawSideMenu(this->storeMode);
 	if (this->storeMode == 7) {
 		/* Release Notes. */
-		std::string title = config->changelog() ? std::string("Universal-Updater ") + C_V : StoreUtils::entries[StoreUtils::store->GetEntry()]->GetTitle();
-		StoreUtils::DrawReleaseNotes(this->scrollOffset, title);
+		StoreUtils::DrawReleaseNotes(this->scrollOffset, StoreUtils::entries[StoreUtils::store->GetEntry()]);
 		return;
 	}
 	if (this->showMarks && StoreUtils::store && StoreUtils::store->GetValid()) StoreUtils::DisplayMarkBox(StoreUtils::entries[StoreUtils::store->GetEntry()]->GetMarks());


### PR DESCRIPTION
This makes the title bar shown on the release notes screen use the entry's accent color.
<img width="640" height="480" alt="_01 08 25_13 24 03 917" src="https://github.com/user-attachments/assets/c9a288d9-c743-49c9-bbb6-a3475a7cfe8a" />
