### PR TITLE
Fix incorrect color showing for selection box in grid view

### DIFF
--- a/source/menu/grid.cpp
+++ b/source/menu/grid.cpp
@@ -81,8 +81,8 @@ void StoreUtils::DrawGrid() {
 
 		for (int i = 0, i2 = -5 + (StoreUtils::store->GetScreenIndx() * 5); i2 < 20 + (StoreUtils::store->GetScreenIndx() * 5) && i2 < (int)StoreUtils::entries.size(); i2++, i++) {
 			uint32_t accentColor = 0;
-			if (config->useAccentColor() && (int)StoreUtils::entries.size() > i + StoreUtils::store->GetScreenIndx()) {
-				accentColor = StoreUtils::entries[i + StoreUtils::store->GetScreenIndx()]->GetAccentColor();
+			if (config->useAccentColor() && (int)StoreUtils::entries.size() > i2 + 5) {
+				accentColor = StoreUtils::entries[i2 + 5]->GetAccentColor();
 			}
 
 			/* Boxes. */


### PR DESCRIPTION
This fixes the wrong color being shown in the selection box in the grid view.
<img width="496" height="480" alt="_01 08 25_14 12 02 08" src="https://github.com/user-attachments/assets/a063520e-2906-408e-9810-b9e1fb1d99f7" />
